### PR TITLE
Fix error when colspans missing in tables

### DIFF
--- a/src/org/emed/main/TableFunctions.java
+++ b/src/org/emed/main/TableFunctions.java
@@ -28,7 +28,10 @@ public class TableFunctions {
 			for (int w = 0; w < childFirstRows.getLength(); w++) {
 				Node childFirstRow = childFirstRows.item(w);
 				if (childFirstRow.getNodeValue() == null && (childFirstRow.getNodeName() == "th" || childFirstRow.getNodeName() == "td")) {
-					int number = Integer.parseInt(childFirstRow.getAttributes().getNamedItem("colspan").getNodeValue());
+					int number = 1;
+					if (childFirstRow.getAttributes().getNamedItem("colspan") != null) {
+						number = Integer.parseInt(childFirstRow.getAttributes().getNamedItem("colspan").getNodeValue());
+					}
 					columnNumber = columnNumber + number;
 				}
 			}
@@ -51,7 +54,11 @@ public class TableFunctions {
 					Node cellNode = cellNodes.item(w);
 					if (cellNode != null && cellNode.getAttributes() != null && cellNode.getAttributes().getNamedItem("colspan") != null) {
 						cell.setColspan(Integer.parseInt(cellNode.getAttributes().getNamedItem("colspan").getNodeValue()));
-						cell.setRowspan(Integer.parseInt(cellNode.getAttributes().getNamedItem("rowspan").getNodeValue()));
+						int rowSpan = 1;
+						if (cellNode.getAttributes().getNamedItem("rowspan") != null) {
+							rowSpan = Integer.parseInt(cellNode.getAttributes().getNamedItem("rowspan").getNodeValue());
+						}
+						cell.setRowspan(rowSpan);
 						ParContent parContent = new ParContent();
 						parContent.setType("tableCell");
 						cell.getParContent().add(parContent);


### PR DESCRIPTION
Hi,
We had some null-pointer exceptions when our xml-file have `<td>` elements without `colspan` and/or `rowspan`. I've changed the code to default to 1 if it is not specified. Hope this doesn't break anything else?

Simon